### PR TITLE
README: make undo-tree comparison more neutral

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -64,9 +64,8 @@ vundo-glyph-alist and has different value now.
 
 Comparing to undo-tree:
 
-I don’t think vundo has any real advantage over undo-tree. On the
-contrary, undo-tree has much more features like diff, etc. (And vundo
-most probably will not add these features.) Vundo is really just a
-code challenge (can we construct an undo tree from linear history)
-came true. One thing I like about vundo is that it lays out the undo
-tree horizontally instead of horizontally.
+Unlike undo-tree vundo uses emacs built-in undo system so it doesn't
+require using an alternative undo-system. Further, vundo is simpler
+without as many features such as diffing for e.g. (And vundo most
+probably will not add more advanced features.) Another difference is
+vundo lays out the undo tree horizontally instead of vertically.


### PR DESCRIPTION
The text read a little self deprecating, update to be more neutral.

---

Note that using undo-tree for me is out of the question, I kept running into bugs where redo fails, with the following [known bug][1], [another report][2] & [reddit thread][3].

There was some work to resolve this, AFAICS it's an inherent conflict with undo-tree and emacs built-in undo.

While it's not the purpose of the README to criticize undo-tree, it is relevant that undo-tree is a large package with known issues that remain unresolved.

If vundo can be kept small & stable, without having to buy into an alternative undo system - this is a feature in it's self.

  [1]: https://lists.ourproject.org/pipermail/implementations-list/2014-November/002091.html
  [2]: https://github.com/syl20bnr/spacemacs/issues/298
  [3]: https://www.reddit.com/r/emacs/comments/85t95p/undo_tree_unrecognized_entry_in_undo_list/