### PR TITLE
Optimization: remove redundant list creation from vundo--eqv-list-of

### DIFF
--- a/vundo.el
+++ b/vundo.el
@@ -391,6 +391,14 @@ modification in MOD-LIST. Return HASH-TABLE."
 ;; We know 3 and 5 are in the same equivalent list because 5 maps to 3
 ;; in `undo-equiv-table' (basically).
 
+(defun vundo--eqv-min-of (mod)
+  "Return the previous most member of MOD.
+Equivalent to: (car (vundo--eqv-list-of mod))"
+  (while (vundo-m-prev-eqv mod)
+    (cl-assert (not (eq mod (vundo-m-prev-eqv mod))))
+    (setq mod (vundo-m-prev-eqv mod)))
+  mod)
+
 (defun vundo--eqv-list-of (mod)
   "Return all the modifications equivalent to MOD."
   (while (vundo-m-prev-eqv mod)
@@ -467,8 +475,7 @@ If FROM non-nil, build from FORM-th modification in MOD-LIST."
            ;; the child.
            (unless (eq m 0)
              (let* ((m-1 (aref mod-list (1- m)))
-                    ;; TODO: may need to optimize.
-                    (min-eqv-mod (car (vundo--eqv-list-of m-1))))
+                    (min-eqv-mod (vundo--eqv-min-of m-1)))
                (setf (vundo-m-parent mod) min-eqv-mod)
                (let ((children (vundo-m-children min-eqv-mod)))
                  ;; If everything goes right, we should never encounter
@@ -729,7 +736,7 @@ This function modifies ‘vundo--prev-mod-list’,
 
 (defun vundo--current-node (mod-list)
   "Return the currently highlighted node in MOD-LIST."
-  (car (vundo--eqv-list-of (aref mod-list (1- (length mod-list))))))
+  (vundo--eqv-min-of (aref mod-list (1- (length mod-list)))))
 
 (defun vundo--highlight-node (node)
   "Highlight NODE as current node."


### PR DESCRIPTION
Add a function to lookup the previous most (min) modification
instead of creating a list only to access it's first element.