### PR TITLE
Optimization: suppress modification-hooks while drawing the tree

### DIFF
--- a/vundo.el
+++ b/vundo.el
@@ -525,7 +525,9 @@ Translate according to ‘vundo-glyph-alist’."
   "Draw the tree in MOD-LIST in current buffer."
   (let* ((root (aref mod-list 0))
          (node-queue (list root))
-         (inhibit-read-only t))
+         (inhibit-read-only t)
+         ;; Harmless but they run each edit adding overhead.
+         (inhibit-modification-hooks t))
     (erase-buffer)
     (while node-queue
       (let* ((node (pop node-queue))


### PR DESCRIPTION
While this isn't so such a problem, there is no need to run these
hooks as they add some overhead on every edit.

---

Noticed jit-lock hooks ran after every edit while profiling.