### PR TITLE
Fix cursor moving to other window after calling vundo-quit

### DIFF
--- a/vundo.el
+++ b/vundo.el
@@ -1162,6 +1162,22 @@ TYPE is the type of buffer you want."
                                      (vundo-1 (current-buffer))
                                      (message "SUCCESS"))))))
 
+;;; Hooks
+
+(defvar vundo-current-buffer nil
+  "Current buffer object when invoking `vundo'.")
+(defun vundo-remember-current-buffer ()
+  (setq vundo-current-buffer (current-buffer)))
+(defun vundo-switch-back-to-original-window ()
+  (catch 'return
+    (dolist (window (window-list))
+      (when (eq (window-buffer window) vundo-current-buffer)
+	(select-window window)
+	(throw 'return nil)))))
+
+(add-hook 'vundo-pre-enter-hook #'vundo-remember-current-buffer)
+(add-hook 'vundo-post-exit-hook #'vundo-switch-back-to-original-window)
+
 (provide 'vundo)
 
 ;;; vundo.el ends here


### PR DESCRIPTION
When there're two windows which spliting horizontally, running (vundo) on the
window above and invoking (vundo-quit) in vundo window, the cursor will move to
the window below, which is quite inconvenient because users have to switch back
to the original window above manually.



https://user-images.githubusercontent.com/52067352/177022735-80f91f2b-a50a-41fb-9065-7028e96d35a1.mp4




