### PR TITLE
Restore selected window after killing vundo buffer

### DIFF
--- a/vundo.el
+++ b/vundo.el
@@ -821,8 +821,11 @@ Roll back changes if `vundo-roll-back-on-quit' is non-nil."
       vundo--orig-buffer vundo--prev-mod-list))
    (with-current-buffer vundo--orig-buffer
      (setq-local buffer-read-only nil))
-   (let ((orig-buffer vundo--orig-buffer))
+   (let* ((orig-buffer vundo--orig-buffer)
+          (orig-window (get-buffer-window orig-buffer)))
      (kill-buffer-and-window)
+     (when (window-live-p orig-window)
+       (select-window orig-window))
      (with-current-buffer orig-buffer
        (run-hooks 'vundo-post-exit-hook)))))
 
@@ -831,8 +834,11 @@ Roll back changes if `vundo-roll-back-on-quit' is non-nil."
   (interactive)
   (with-current-buffer vundo--orig-buffer
     (setq-local buffer-read-only nil))
-  (let ((orig-buffer vundo--orig-buffer))
+  (let* ((orig-buffer vundo--orig-buffer)
+         (orig-window (get-buffer-window orig-buffer)))
     (kill-buffer-and-window)
+    (when (window-live-p orig-window)
+      (select-window orig-window))
     (with-current-buffer orig-buffer
       (run-hooks 'vundo-post-exit-hook))))
 


### PR DESCRIPTION
It is not always the case that Emacs will select the original buffer's window after killing the vundo buffer and window, this is especially true when using a window manager such as windows-purpose. This PR makes sure the original buffer's window is reselected after killing vundo's window.