### PR TITLE
Improve timestamp handling

### DIFF
--- a/vundo.el
+++ b/vundo.el
@@ -553,14 +553,18 @@ Translate according to `vundo-glyph-alist'."
                   vundo-glyph-alist)))
               text 'string))
 
-(defun vundo--mod-timestamp (mod-list idx)
-  "Return a timestamp if the mod in MOD-LIST at IDX has a timestramp."
-  ;; If the next mod’s timestamp is non-nil, this mod/node
-  ;; represents a saved state.
-  (let* ((next-mod-idx (1+ idx))
-         (next-mod (when (< next-mod-idx (length mod-list))
-                     (aref mod-list next-mod-idx))))
-    (and next-mod (vundo-m-timestamp next-mod))))
+(defun vundo--mod-timestamp (mod-list mod)
+  "Return a timestamp if the MOD node in MOD-LIST has a timestamp."
+  ;; If the next mod’s timestamp is non-nil for any equivalent node,
+  ;; this mod/node represents a saved state.
+  (if-let ((eqvs (vundo--eqv-list-of mod)))
+      (seq-some (lambda (node)
+                  (let* ((idx (vundo-m-idx node))
+                         (next-mod-idx (1+ idx))
+                         (next-mod (when (< next-mod-idx (length mod-list))
+                                     (aref mod-list next-mod-idx))))
+                    (and next-mod (vundo-m-timestamp next-mod))))
+                eqvs)))
 
 (defvar vundo--last-saved-idx)
 
@@ -585,7 +589,7 @@ corresponding to the index of the last saved node."
              (node-last-child-p (and parent (eq node (car (last siblings)))))
              (node-idx (vundo-m-idx node))
              (saved-p (and vundo-highlight-saved-nodes
-                           (vundo--mod-timestamp mod-list node-idx)))
+                           (vundo--mod-timestamp mod-list node)))
              (node-face (if saved-p 'vundo-saved 'vundo-node))
              (stem-face (if only-child-p 'vundo-stem 'vundo-branch-stem)))
         (when (and saved-p (> node-idx last-saved-idx))
@@ -1313,8 +1317,7 @@ TYPE is the type of buffer you want."
              (and (vundo-m-children node)
                   (mapcar #'vundo-m-idx (vundo-m-children node)))
              (if-let* ((vundo-highlight-saved-nodes)
-                       (ts (vundo--mod-timestamp vundo--prev-mod-list
-                                                 (vundo-m-idx node)))
+                       (ts (vundo--mod-timestamp vundo--prev-mod-list node))
                        ((consp ts)))
                  (format " Saved: %s" (format-time-string "%F %r" ts))
                ""))))

--- a/vundo.el
+++ b/vundo.el
@@ -379,7 +379,7 @@ If MOD-LIST non-nil, extend on MOD-LIST."
             (cl-incf uidx))
           ;; If this modification contains a timestamp, the previous
           ;; state is saved to file.
-          (when (and mod-timestamp (not pos-only))
+          (when (and mod-timestamp (> mod-timestamp 0) (not pos-only))
             (setf (vundo-m-timestamp (car new-mlist)) mod-timestamp)))))
     ;; Convert to vector.
     (vconcat mod-list new-mlist)))

--- a/vundo.el
+++ b/vundo.el
@@ -1111,11 +1111,17 @@ the INCREMENTAL option in `vundo--refresh-buffer' anymore."
                          return node
                          finally return nil)))
       (with-current-buffer buffer
-        (setq buffer-undo-list
-              (vundo-m-undo-list possible-trim-point)))
-      (when vundo--message
-        (message "Trimmed to: %s"
-                 (vundo-m-idx possible-trim-point))))))
+        (let ((tail buffer-undo-list))
+	  (setq buffer-undo-list
+		(vundo-m-undo-list possible-trim-point))
+	  (when vundo--message
+            (message "Trimmed to: %s"
+                     (vundo-m-idx possible-trim-point))
+	    (while (and tail (not (eq tail buffer-undo-list)))
+	      (when (and (consp (car tail)) (eq (caar tail) t) (consp (cdar tail)))
+		(message "!!! Trimmed a TimeStamp: %s"
+			 (format-time-string "%F %r" (cdar tail))))
+	      (setq tail (cdr tail)))))))))
 
 (defun vundo-forward (arg)
   "Move forward ARG nodes in the undo tree.

--- a/vundo.el
+++ b/vundo.el
@@ -379,7 +379,7 @@ If MOD-LIST non-nil, extend on MOD-LIST."
             (cl-incf uidx))
           ;; If this modification contains a timestamp, the previous
           ;; state is saved to file.
-          (when (and mod-timestamp (> mod-timestamp 0) (not pos-only))
+          (when (and mod-timestamp (consp mod-timestamp) (not pos-only))
             (setf (vundo-m-timestamp (car new-mlist)) mod-timestamp)))))
     ;; Convert to vector.
     (vconcat mod-list new-mlist)))


### PR DESCRIPTION
undo creates "unknown" timestamps like `(t . 0)` when it doesn't know the buffer/file modification time.  This ignores those, since they can be a nuisance, e.g. in `vundo-stress-test`.  In addition, this enables logging when trimming the "unnecessary" tail of `buffer-undo-list` removes timestamp data (see #66).