### PR TITLE
Move among all saved nodes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,11 +8,13 @@ should pop up. To move around, type:
   f   to go forward
   b   to go backward
 
-  n   to go to the node below when you at a branching point
+  n   to go to the node below when at a branch point
   p   to go to the node above
 
   a   to go back to the last branching point
   e   to go forward to the end/tip of the branch
+  l   to go to the last saved node
+  r   to go to the next saved node
 
   m   to mark the current node for diff
   u   to unmark the marked node

--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -87,9 +87,7 @@ CURRENT node."
           (goto-char (point-min))
           (dolist (c change-files) ; change the file names in the diff
             (when (search-forward (car c) lim t)
-              (replace-match (cdr c))))))
-
-      (run-hooks 'vundo-diff-setup-hook))))
+              (replace-match (cdr c)))))))))
 
 ;;;###autoload
 (defun vundo-diff-mark (&optional node)

--- a/vundo.el
+++ b/vundo.el
@@ -40,6 +40,7 @@
 ;;   a   to go back to the last branching point
 ;;   e   to go forward to the end/tip of the branch
 ;;   l   to go to the last saved node
+;;   r   to go to the next saved node
 ;;
 ;;   m   to mark the current node for diff
 ;;   u   to unmark the marked node
@@ -217,7 +218,6 @@ most recent such node, which receives the face `vundo-last-saved'."
   :type '(choice (const :tag "Bottom" bottom)
                  (const :tag "Top"    top)))
 
-;;;###autoload
 (defconst vundo-ascii-symbols
   '((selected-node . ?x)
     (node . ?o)
@@ -227,7 +227,6 @@ most recent such node, which receives the face `vundo-last-saved'."
     (last-branch . ?`))
   "ASCII symbols to draw vundo tree.")
 
-;;;###autoload
 (defconst vundo-unicode-symbols
   '((selected-node . ?●)
     (node . ?○)
@@ -291,13 +290,6 @@ the user invoked ‘vundo’, before every setup ‘vundo’ does."
 This hook runs in the original buffer the user invoked ‘vundo’,
 after all the clean up the exiting function does. Ie, it is the
 very last thing that happens when vundo exists."
-  :type 'hook)
-
-(defcustom vundo-diff-setup-hook nil
-  "List of functions to call after creating a diff buffer.
-This hook runs in the ‘vundo-diff’ buffer immediately after it's setup,
-both for new or existing buffers. This may be used to
-manipulate the diff or transform it's contents."
   :type 'hook)
 
 ;;; Undo list to mod list
@@ -526,35 +518,77 @@ If FROM non-nil, build from FORM-th modification in MOD-LIST."
                                         'reverse))))))))))
 
 ;;; Timestamps
-;; buffer-undo-list contains "timestamp entries" like (t . TIMESTAMP)
-;; which capture the file modification time of the saved file which
-;; an undo changed.  During tree draw, we collect the last of these, and
-;; indicated nodes which had been saved specially.
 
-(defvar vundo--last-saved-idx)
+;; buffer-undo-list contains "timestamp entries" within a record like
+;; (t . TIMESTAMP).  These capture the file modification time of the
+;; saved file which that undo changed (i.e. the TIMESTAMP applies to
+;; the prior state).  While reading the undo list, we collect these,
+;; sort them, and during tree draw, indicate nodes which had been
+;; saved specially.  Note that the buffer associated with the current
+;; node can be saved, but not yet modified by an undo/redo; this is
+;; handled specially.
+
+(defvar-local vundo--timestamps nil
+  "Mapping between the oldest equivalent node and modification time.
+Sorted by time, with latest saved mods first.  Only undo-based
+modification times are included; see `vundo--node-timestamp'.")
+
+(defun vundo--record-timestamps (mod-list)
+  "Record all the timestamps in MOD-LIST."
+  (let ((timestamps '()))
+    (cl-loop for idx from 1 below (length mod-list)
+             for ts = (vundo-m-timestamp (aref mod-list idx))
+             if ts do
+             (let* ((mod-node (aref mod-list (1- idx)))
+                    (master (vundo--master-eqv-mod-of mod-node))
+                    (old-ts (cdr (assq master timestamps))))
+               (when (and old-ts (time-less-p ts old-ts))
+                 (setq ts old-ts)) ; equivalent node modified again? take the newer time
+               (setf (alist-get master timestamps nil nil #'eq) ts)))
+    (sort timestamps  ; sort latest first
+          (lambda (a b) (time-less-p (cdr b) (cdr a))))))
+
+(defun vundo--find-last-saved (node &optional arg)
+  "Return the last saved node prior to NODE.
+ARG (default 1) specifies the number of saved nodes to move
+backwards in history.  ARG<0 indicates moving that many saved
+nodes forward in history.  Returns nil if no such saved node
+exists."
+  (let* ((arg (or arg 1))
+         (past (>= arg 0))
+         (cnt (abs arg))
+         (master (vundo--master-eqv-mod-of node))
+         (midx (vundo-m-idx master))
+         last-node)
+    (if (assq master vundo--timestamps)
+        (setq last-node master)
+      ;; no TS here, find closest master idx on saved list in direction ARG
+      (cl-loop with val = (if past -1 most-positive-fixnum)
+               with between = (if past #'< #'>)
+               for (n . _) in vundo--timestamps
+               for idx = (vundo-m-idx n)
+               if (funcall between val idx midx) do (setq val idx last-node n))
+      (when last-node (setq cnt (1- cnt))))  ; used up one getting started
+    (if (and last-node (> cnt 0))            ; found one, but more to go
+        (let ((vt (if past vundo--timestamps (reverse vundo--timestamps))))
+          (while (and vt (not (eq (caar vt) last-node))) (setq vt (cdr vt)))
+          (caar (nthcdr cnt vt)))
+      last-node)))
+
 (defvar vundo--orig-buffer)
-
-(defun vundo--mod-timestamp (mod-list idx)
-  "Return a timestamp if the mod in MOD-LIST at IDX has a timestamp."
-  ;; If the next mod’s timestamp is non-nil, this mod/node
-  ;; represents a saved state.
-  (let* ((next-mod-idx (1+ idx))
-         (next-mod (when (< next-mod-idx (length mod-list))
-                     (aref mod-list next-mod-idx))))
-    (and next-mod (vundo-m-timestamp next-mod))))
-
-(defun vundo--node-timestamp (mod-list node)
+(defun vundo--node-timestamp (mod-list node &optional no-buffer)
   "Return a timestamp from MOD-LIST for NODE, if any.
-In addition to undo-based timestamps, this includes the modtime of the
-current buffer (if unmodified)."
-  (let* ((idx (vundo-m-idx node))
-         (current (vundo--current-node mod-list)))
-    (or (vundo--mod-timestamp mod-list idx)
-        (and (eq node current) (eq idx vundo--last-saved-idx)
+In addition to undo-based timestamps, this includes the modtime
+of the current buffer (if it has an associated file which is
+unmodified and NO-BUFFER is non-nil)."
+  (when-let ((master (vundo--master-eqv-mod-of node)))
+    (or (alist-get master vundo--timestamps nil nil #'eq)
+        (and (eq node (vundo--current-node mod-list))
              (with-current-buffer vundo--orig-buffer
-               (and (buffer-file-name)
+               (and (not no-buffer) (buffer-file-name)
                     (not (buffer-modified-p))
                     (visited-file-modtime)))))))
+
 ;;; Draw tree
 
 (defun vundo--put-node-at-point (node)
@@ -595,20 +629,13 @@ Translate according to `vundo-glyph-alist'."
                   vundo-glyph-alist)))
               text 'string))
 
-(defvar vundo--last-saved-idx)
-
-(defun vundo--draw-tree (mod-list orig-buffer-modified)
-  "Draw the tree in MOD-LIST in current buffer.
-ORIG-BUFFER-MODIFIED is t if the original buffer is not saved to
-the disk.  Set `vundo--last-saved-idx' by side-effect,
-corresponding to the index of the last saved node."
+(defun vundo--draw-tree (mod-list)
+  "Draw the tree in MOD-LIST in current buffer."
   (let* ((root (aref mod-list 0))
          (node-queue (list root))
          (inhibit-read-only t)
-         (inhibit-modification-hooks t)
-         (last-saved-idx -1))
+         (inhibit-modification-hooks t))
     (erase-buffer)
-    (setq vundo--last-saved-idx -1)
     (while node-queue
       (let* ((node (pop node-queue))
              (children (vundo-m-children node))
@@ -616,13 +643,10 @@ corresponding to the index of the last saved node."
              (siblings (and parent (vundo-m-children parent)))
              (only-child-p (and parent (eq (length siblings) 1)))
              (node-last-child-p (and parent (eq node (car (last siblings)))))
-             (node-idx (vundo-m-idx node))
-             (mod-ts (vundo--mod-timestamp mod-list node-idx))
-             (saved-p (and vundo-highlight-saved-nodes mod-ts))
-             (node-face (if saved-p 'vundo-saved 'vundo-node))
+             (mod-ts (vundo--node-timestamp mod-list node 'no-buffer))
+             (node-face (if (and vundo-highlight-saved-nodes mod-ts)
+                            'vundo-saved 'vundo-node))
              (stem-face (if only-child-p 'vundo-stem 'vundo-branch-stem)))
-        (when (and mod-ts (> node-idx last-saved-idx))
-          (setq last-saved-idx node-idx))
         ;; Go to parent.
         (if parent (goto-char (vundo-m-point parent)))
         (let ((room-for-another-rx
@@ -676,20 +700,7 @@ corresponding to the index of the last saved node."
         ;; Associate the text node in buffer with the node object.
         (vundo--put-node-at-point node)
         ;; Depth-first search.
-        (setq node-queue (append children node-queue))))
-
-    ;; If the associated buffer is unmodified, the last node must be
-    ;; the last saved node even though it doesn’t (yet) have a next
-    ;; node with a timestamp to indicate that.
-    (setq vundo--last-saved-idx
-          (if orig-buffer-modified
-              (if (> last-saved-idx 0) last-saved-idx nil)
-            (vundo-m-idx (vundo--current-node mod-list))))
-    ;; Update the face of the last saved node (if any).
-    (when (and vundo-highlight-saved-nodes
-               vundo--last-saved-idx)
-      (vundo--highlight-last-saved-node
-       (aref mod-list vundo--last-saved-idx)))))
+        (setq node-queue (append children node-queue))))))
 
 ;;; Vundo buffer and invocation
 
@@ -721,6 +732,7 @@ WINDOW is the window that was/is displaying the vundo buffer."
     (define-key map (kbd "a") #'vundo-stem-root)
     (define-key map (kbd "e") #'vundo-stem-end)
     (define-key map (kbd "l") #'vundo-goto-last-saved)
+    (define-key map (kbd "r") #'vundo-goto-next-saved)
     (define-key map (kbd "q") #'vundo-quit)
     (define-key map (kbd "C-g") #'vundo-quit)
     (define-key map (kbd "RET") #'vundo-confirm)
@@ -762,10 +774,6 @@ WINDOW is the window that was/is displaying the vundo buffer."
   "Vundo will roll back to this node.")
 (defvar-local vundo--highlight-overlay nil
   "Overlay used to highlight the selected node.")
-(defvar-local vundo--last-saved-idx nil
-  "The last node index with a timestamp seen.
-This is set by ‘vundo--draw-tree’ and ‘vundo-save’, and used by
-‘vundo-goto-last-saved’ and ‘vundo--highlight-last-saved-node’.")
 (defvar-local vundo--highlight-last-saved-overlay nil
   "Overlay used to highlight the last saved node.")
 
@@ -801,8 +809,7 @@ This function modifies `vundo--prev-mod-list',
     (when (not incremental)
       (setq vundo--prev-undo-list nil
             vundo--prev-mod-list nil
-            vundo--prev-mod-hash nil
-            vundo--last-saved-idx nil)
+            vundo--prev-mod-hash nil)
       ;; Give the garbage collector a chance to release
       ;; `buffer-undo-list': GC cannot release cons cells when all
       ;; these stuff are referring to it.
@@ -841,21 +848,28 @@ This function modifies `vundo--prev-mod-list',
           ;; Build tree.
           (vundo--build-tree mod-list mod-hash
                              (length vundo--prev-mod-list))))
+      
+      ;; Update cache.
+      (setq vundo--prev-mod-list mod-list
+            vundo--prev-mod-hash mod-hash
+            vundo--prev-undo-list undo-list
+            vundo--orig-buffer orig-buffer)
+      
+      ;; Record timestamps
+      (setq vundo--timestamps (vundo--record-timestamps mod-list))
+
       ;; 3. Render buffer. We don't need to redraw the tree if there
       ;; is no change to the nodes.
       (unless (eq (vundo--latest-buffer-state mod-list) latest-state)
-        (vundo--draw-tree mod-list (with-current-buffer orig-buffer
-                                     (buffer-modified-p))))
+        (vundo--draw-tree mod-list))
 
       ;; Highlight current node.
       (vundo--highlight-node (vundo--current-node mod-list))
       (goto-char (vundo-m-point (vundo--current-node mod-list)))
 
-      ;; Update cache.
-      (setq vundo--prev-mod-list mod-list
-            vundo--prev-mod-hash mod-hash
-            vundo--prev-undo-list undo-list
-            vundo--orig-buffer orig-buffer))))
+      ;; Highlight the last saved node extra specially
+      (when vundo-highlight-saved-nodes
+        (vundo--highlight-last-saved-node mod-list vundo--timestamps)))))
 
 (defun vundo--current-node (mod-list)
   "Return the currently highlighted node in MOD-LIST."
@@ -877,15 +891,26 @@ This function modifies `vundo--prev-mod-list',
                 (1- (vundo-m-point node))
                 (vundo-m-point node)))
 
-(defun vundo--highlight-last-saved-node (node)
-  "Highlight NODE as the last saved.
-This moves the overlay `vundo--highlight-last-saved-overlay'."
-  (let ((node-pt (vundo-m-point node)))
-    (unless vundo--highlight-last-saved-overlay
-      (setq vundo--highlight-last-saved-overlay
-            (make-overlay (1- node-pt) node-pt))
-      (overlay-put vundo--highlight-last-saved-overlay 'face 'vundo-last-saved))
-    (move-overlay vundo--highlight-last-saved-overlay (1- node-pt) node-pt)))
+(defun vundo--highlight-last-saved-node (mod-list timestamps)
+  "Highlight the last (latest) saved node on MOD-LIST.
+Consults the alist of TIMESTAMPS.  This moves the overlay
+`vundo--highlight-last-saved-overlay'."
+  (let* ((last-saved (car timestamps))
+         (cur (vundo--current-node mod-list))
+         (cur-ts (vundo--node-timestamp mod-list cur))
+         (node (cond ((and last-saved cur-ts)
+                      (if (time-less-p (cdr last-saved) cur-ts)
+                          cur (car last-saved)))
+                     (last-saved (car last-saved))
+                     (cur-ts cur)
+                     (t nil)))
+         (node-pt (and node (vundo-m-point node))))
+    (when node-pt
+      (unless vundo--highlight-last-saved-overlay
+        (setq vundo--highlight-last-saved-overlay
+              (make-overlay (1- node-pt) node-pt))
+        (overlay-put vundo--highlight-last-saved-overlay 'face 'vundo-last-saved))
+      (move-overlay vundo--highlight-last-saved-overlay (1- node-pt) node-pt))))
 
 ;;;###autoload
 (defun vundo ()
@@ -1294,21 +1319,30 @@ If ARG < 0, move forward."
       vundo--orig-buffer (current-buffer)
       'incremental))))
 
-(defun vundo-goto-last-saved ()
-  "Goto the last saved node, if any."
-  (interactive)
-  (when (and vundo--last-saved-idx (>= vundo--last-saved-idx 0))
-    (vundo--check-for-command
-     (when-let* ((this (vundo--current-node vundo--prev-mod-list))
-                 (dest (aref vundo--prev-mod-list vundo--last-saved-idx)))
-       (unless (eq this dest)
-         (vundo--move-to-node
-          this dest vundo--orig-buffer vundo--prev-mod-list)
-         (vundo--trim-undo-list
-          vundo--orig-buffer dest vundo--prev-mod-list)
-         (vundo--refresh-buffer
-          vundo--orig-buffer (current-buffer)
-          'incremental))))))
+(defun vundo-goto-last-saved (arg)
+  "Go back to the first saved node prior to the current node, if any.
+With numeric prefix ARG, move that many saved nodes back (ARG<0
+moves forward in history)."
+  (interactive "p")
+  (if-let* ((cur (vundo--current-node vundo--prev-mod-list))
+            (dest (vundo--find-last-saved cur arg)))
+      (progn
+        (unless (eq cur dest)
+          (vundo--check-for-command
+           (vundo--move-to-node cur dest vundo--orig-buffer vundo--prev-mod-list)
+           (vundo--trim-undo-list vundo--orig-buffer dest vundo--prev-mod-list)
+           (vundo--refresh-buffer vundo--orig-buffer (current-buffer) 'incremental)))
+        (message "Node saved %s"
+                 (format-time-string
+                  "%F %r"
+                  (vundo--node-timestamp vundo--prev-mod-list dest))))
+    (message "No such saved node")))
+
+(defun vundo-goto-next-saved (arg)
+  "Go to the ARGth saved node after the current node (default 1).
+For ARG<0, got the last saved node prior to the current node."
+  (interactive "p")
+  (vundo-goto-last-saved (- arg)))
 
 (defun vundo-save (arg)
   "Run `save-buffer' with the current buffer Vundo is operating on.
@@ -1317,10 +1351,8 @@ Accepts the same interactive arfument ARG as ‘save-buffer’."
   (vundo--check-for-command
    (with-current-buffer vundo--orig-buffer
      (save-buffer arg)))
-  (let* ((cur-node (vundo--current-node vundo--prev-mod-list)))
-    (setq vundo--last-saved-idx (vundo-m-idx cur-node))
-    (when vundo-highlight-saved-nodes
-      (vundo--highlight-last-saved-node cur-node))))
+  (when vundo-highlight-saved-nodes
+    (vundo--highlight-last-saved-node vundo--prev-mod-list vundo--timestamps)))
 
 ;;; Debug
 


### PR DESCRIPTION
This PR enables `l` + `r` to move left and right = earlier and later among all saved nodes, in time order.  It is very useful with the new mark/diff functionality of #78: `(m)ark`, `(l)ast`, `(d)iff` is an especially powerful combo.

## Changes:

- `record-timestamps`: new function to record the timestamps discovered in the mod-list into a sorted (recent-first) alist of `master_node -> timestamp`: `vundo--timestamps`.
- `last-saved-index` + `mod-timestamp`: no longer necessary, removed.
- `find-last-saved-node`: consults the above to find the node with saved timestamp `N` steps older/newer than the current (if any).
- `goto-last-saved`: use `find-last-saved-node` to step to `N`th prior saved node.
- `goto-next-saved`: (`r` binds here), goes to _next_ saved node after current (`goto-last-saved` with `N<0`).

Note that the timestamp alist is keyed by the _master node_ of saved-then-changed nodes and records only the latest timestamp.  There reason is that, for such nodes, zero or more equivalent nodes may have a timestamp in their next undo mod (zero if a TS is lost, see below).

## TS Lossage

The one issue remaining is detailed in #73: the loss of timestamp data at the hands of `trim-undo-list`.  This only occurs if you move back to an older node on the tree, save, and either add new non-undo edits (creating a new branch), or navigate away from there via other undos/redos.  Often this "superfluous" undo is trimmed as soon as you move, since vundo reasons that it can easily reach that node without the more recent time-stamped undo record.  Sometimes a "late TS" record like this can persist across vundo cycles, only to be trimmed later.  I've added some temporary debugging so it's easy to see when such lossage occurs -- `Trimming TS at <datetime>`.

In practice this means that if you navigate back and save an older state, that timestamp is reasonably likely to be lost to trimming.  Right now this doesn't cause a redraw, so a green circle can remain visible, but have no associated TS.  Note that sometimes, depending on the sequence of undos/redos/edits, the same TS can appear after multiple equivalent nodes so losing one or more of these is non-problematic.

## TS Loss Solutions 
I see 3 possibilities:

1. Store about-to-be-trimmed TS data in an **auxiliary cache**. We could simply add `master_node -> time_stamp` to some separate alist like `vundo--buffer-timestamps` every time we detect a new unmodified buffer, or an impending TS lossage (assuming these nodes are not already on the "real" TS list).  Then, when navigating among saved nodes, consult both lists, as a backup.  This won't survive a round-trip to disk with `undo-fu-session` or similar.  And we'd need to save this state data to the buffer itself if we want it to persist between subsequent vundo sessions.
2. As outlined in #73, simply **copy that timestamp record** (e.g. `(t 25975 38996 365335 419000)`) back into the next node after the `master-eqv-mod-of` the record prior to the mod whose TS is about to be lost (if it has no TS, or an older one).  I.e. when trimming `buffer-undo-list`, for equivalent nodes `1a`, `1b` go from:
    ```... new_child(1b, TS) <- new_parent(1b)  ... old_child(1a) <- old_parent(1a)```
	to:	
   ```[Trimmed: ... new_child(1b, TS) <- new_parent(1b)] ... old_child(1a, TS) <- old_parent(1a)```
3. Just **ignore the lossage**, but show it, i.e. update draw if you detect a TS has been trimmed.  Recall that lossage only happens when you _revisit_ a state, save it anew, then modify it or navigate away from it.  I.e. when you accumulate new modification TS's at the end of the undo list.

While number 2 is effectively rewriting history to claim that the modification to that state happened "back then", we are in a sense already doing this by eliminating superfluous recent undo records.  In other words, vundo posits that the _structure of the tree_ is what matters, not the particular historical sequence of edits/undos/redos that led to that structure (which grows quite convoluted with vundo movement).

Thoughts?