### PR TITLE
Speedup draw-tree (+ document diff-keys)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,6 +14,10 @@ should pop up. To move around, type:
   a   to go back to the last branching point
   e   to go forward to the end/tip of the branch
 
+  m   to mark the current node for diff
+  u   to unmark the marked node
+  d   to show a diff between the marked (or parent) and current nodes
+
   q   to quit, you can also type C-g
 
   C-c C-s (or whatever binding you used for save-buffer)

--- a/vundo.el
+++ b/vundo.el
@@ -616,8 +616,7 @@ corresponding to the index of the last saved node."
           (setq last-saved-idx node-idx))
         ;; Go to parent.
         (if parent (goto-char (vundo-m-point parent)))
-        (let ((col (max 0 (1- (current-column))))
-              (room-for-another-rx
+        (let ((room-for-another-rx
                (rx-to-string
                 `(or (>= ,(if vundo-compact-display 3 4) ?\s) eol))))
           (if (null parent)
@@ -629,7 +628,7 @@ corresponding to the index of the last saved node."
               ;;             |     child to 1 but is blocked
               ;;             +--4  by that plus sign.
               (while (not (looking-at room-for-another-rx))
-                (vundo--next-line-at-column col)
+                (vundo--next-line-at-column (max 0 (1- (current-column))))
                 ;; When we go down, we could encounter space, EOL, │,
                 ;; ├, or └. Space and EOL should be replaced by │, ├
                 ;; and └ should be replaced by ├.


### PR DESCRIPTION
This simple fixes makes calls to `(current-column)` happen only when needed during `draw-tree` -- when there is no room for a new branch.  Since `current-column` gets quite slow on long lines, calling it unnecessarily on each node in the tree leads to major (quadratically bad) slowdown.