### PR TITLE
Add "vundo-diff-setup-hook" for manipulating the diff for display

### DIFF
--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -87,7 +87,9 @@ CURRENT node."
           (goto-char (point-min))
           (dolist (c change-files) ; change the file names in the diff
             (when (search-forward (car c) lim t)
-              (replace-match (cdr c)))))))))
+              (replace-match (cdr c))))))
+
+      (run-hooks 'vundo-diff-setup-hook))))
 
 ;;;###autoload
 (defun vundo-diff-mark (&optional node)

--- a/vundo.el
+++ b/vundo.el
@@ -291,6 +291,13 @@ after all the clean up the exiting function does. Ie, it is the
 very last thing that happens when vundo exists."
   :type 'hook)
 
+(defcustom vundo-diff-setup-hook nil
+  "List of functions to call after creating a diff buffer.
+This hook runs in the ‘vundo-diff’ buffer immediately after it's setup,
+both for new or existing buffers. This may be used to
+manipulate the diff or transform it's contents."
+  :type 'hook)
+
 ;;; Undo list to mod list
 
 (cl-defstruct vundo-m


### PR DESCRIPTION
This PR adds a hook that runs after the vundo-diff buffer has been setup (created or re-initialized with new contents).

This can be useful for manipulating the diff buffer, for example, I'm currently using two hooks:

```
  ;; Remove noisy "Diff finished" message.
  (add-hook
   'vundo-diff-setup-hook
   (lambda ()
     (save-excursion
       (goto-char (point-max))
       (forward-line -2)
       (when (looking-at-p "\nDiff finished\\.  ")
         (delete-region (point) (point-max))))))
```
---

This hook uses the [diff-ansi](https://codeberg.org/ideasman42/emacs-diff-ansi) package for easier to read diffs:

```
  (add-hook
   'vundo-diff-setup-hook
   (lambda ()
     (font-lock-mode -1)
     (setq-local diff-ansi-method 'immediate)
     (save-excursion
       (goto-char (point-min))
       (forward-line 1)
       (diff-ansi-region (point) (point-max)))))
```

This allows delta to be used for diff display, which supports side-by-side view, syntax-highlighting and character level difference display which I find easier to parse:

[screenshot.webm](https://github.com/casouri/vundo/assets/1869379/c6106de1-487c-4ebd-9cff-e80e48cd0a33)


---


Note that I had to adjust the filename formatting for `delta` to syntax highlight properly, perhaps the diff filename formatting could be configurable eventually, that's outside the scope of this PR though.

```
--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -58,7 +58,7 @@ CURRENT node."
                                     (if vundo-diff--marked-node "Marked" "Parent"))
                        collect
                        (list (format "[%d]" idx)
-                             (format "<%s> [mod %d] (%s)" orig-name idx stat)
+                             (format "[mod %d] (%s) %s"  idx stat orig-name)
                              (when (consp ts) (format-time-string "%F %r" ts)))))
         lim)
     (with-current-buffer buf
```