### PR TITLE
Option to close the diff buffer when quitting

### DIFF
--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -161,6 +161,20 @@ the original buffer name."
               (display-buffer dbuf)))
         (kill-buffer mrkbuf)))))
 
+;;;###autoload
+(defun vundo-diff-quit ()
+  "Close the diff buffer & window, when found."
+  (interactive)
+  (when vundo--orig-buffer
+    (let* ((orig vundo--orig-buffer)
+           (oname (buffer-name orig))
+           (dbuf (get-buffer (concat "*vundo-diff-" oname "*"))))
+      (when dbuf
+        (let ((dbuf-window (get-buffer-window dbuf)))
+          (when dbuf-window
+            (delete-window dbuf-window))
+          (kill-buffer dbuf))))))
+
 (defconst vundo-diff-font-lock-keywords
   `((,(rx bol (or "---" "+++") (* nonl) "[mod " (group (+ num)) ?\]
           (+ ?\s) ?\((group (or "Parent" "Current")) ?\))

--- a/vundo.el
+++ b/vundo.el
@@ -202,6 +202,10 @@
   "If non-nil, vundo will roll back the change when it quits."
   :type 'boolean)
 
+(defcustom vundo-diff-quit nil
+  "If non-nil, vundo will close the `vundo-diff' buffer on quit."
+  :type 'boolean)
+
 (defcustom vundo-highlight-saved-nodes t
   "If non-nil, vundo will highlight nodes which have been saved and then modified.
 The face `vundo-saved' is used for saved nodes, except for the
@@ -706,6 +710,7 @@ WINDOW is the window that was/is displaying the vundo buffer."
         (kill-buffer-and-window))))
 
 (declare-function vundo-diff "vundo-diff")
+(declare-function vundo-diff-quit "vundo-diff")
 (declare-function vundo-diff-mark "vundo-diff")
 (declare-function vundo-diff-unmark "vundo-diff")
 (defvar vundo-mode-map
@@ -969,6 +974,8 @@ Roll back changes if `vundo-roll-back-on-quit' is non-nil."
       vundo--orig-buffer vundo--prev-mod-list))
    (with-current-buffer vundo--orig-buffer
      (setq-local buffer-read-only nil))
+   (when vundo-diff-quit
+     (vundo-diff-quit))
    (let* ((orig-buffer vundo--orig-buffer)
           (orig-window (get-buffer-window orig-buffer)))
      (kill-buffer-and-window)


### PR DESCRIPTION
Implement #88 outlined here.

Note this is off by default so there is no functional change unless `vundo-diff-quit` is enabled.

---

Note that I'm not sure if many users would want to keep the buffer open? The option could be removed and this could even be enabled by default.