### PR TITLE
Fix error activating an diff at the root of the tree

### DIFF
--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -129,10 +129,11 @@ the original buffer name."
 	 (oname (buffer-name orig))
 	 (current (vundo--current-node vundo--prev-mod-list))
 	 (marked (or vundo-diff--marked-node (vundo-m-parent current)))
-	 (swapped (> (vundo-m-idx marked) (vundo-m-idx current)))
+	 swapped
 	 mrkbuf)
     (if (or (not current) (not marked) (eq current marked))
 	(message "vundo diff not available.")
+      (setq swapped (> (vundo-m-idx marked) (vundo-m-idx current)))
       (setq mrkbuf (get-buffer-create
 		    (make-temp-name (concat oname "-vundo-diff-marked"))))
       (unwind-protect


### PR DESCRIPTION
When activating vundo-diff when there are no previous undo steps, an error would be raised.

`funcall-interactively: Wrong type argument: vundo-m, nil`

Now the message `vundo diff not available.` is shown.