### PR TITLE
quit(/kill) vundo-diff window+buffer on vundo-quit

### DIFF
--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -34,6 +34,14 @@
 (require 'diff-mode)
 (eval-when-compile (require 'cl-lib))
 
+(defcustom vundo-diff-quit t
+  "If non-nil, bury the `vundo-diff' window when vundo is quit.
+If set to \\='kill, the diff buffer will also be killed."
+  :group 'vundo
+  :type '(choice (const :tag "Do not quit" nil)
+                 (const :tag "Quit window" t)
+                 (const :tag "Quit window and kill buffer" kill)))
+
 (defface vundo-diff-highlight
   '((((background light)) .
      (:inherit vundo-highlight :foreground "DodgerBlue4"))
@@ -120,6 +128,14 @@ NODE defaults to the current node."
     (when vundo-diff--highlight-overlay
       (delete-overlay vundo-diff--highlight-overlay)
       (setq vundo-diff--highlight-overlay nil))))
+
+(defun vundo-diff--quit ()
+  "Quit the `vundo-diff' window and possibly kill buffer."
+  (let* ((buf (get-buffer (concat "*vundo-diff-" (buffer-name) "*")))
+	 (win (and buf (get-buffer-window buf)))
+         (kill (eq vundo-diff-quit 'kill)))
+    (if win (quit-window kill win)
+      (when (and buf kill) (kill-buffer buf)))))
 
 ;;;###autoload
 (defun vundo-diff ()

--- a/vundo.el
+++ b/vundo.el
@@ -745,6 +745,7 @@ WINDOW is the window that was/is displaying the vundo buffer."
 (declare-function vundo-diff "vundo-diff")
 (declare-function vundo-diff-mark "vundo-diff")
 (declare-function vundo-diff-unmark "vundo-diff")
+(declare-function vundo-diff--quit "vundo-diff")
 (defvar vundo-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "f") #'vundo-forward)
@@ -1028,6 +1029,7 @@ Roll back changes if `vundo-roll-back-on-quit' is non-nil."
      (when (window-live-p orig-window)
        (select-window orig-window))
      (with-current-buffer orig-buffer
+       (vundo-diff--quit)
        (run-hooks 'vundo-post-exit-hook)))))
 
 (defun vundo-confirm ()
@@ -1041,6 +1043,7 @@ Roll back changes if `vundo-roll-back-on-quit' is non-nil."
     (when (window-live-p orig-window)
       (select-window orig-window))
     (with-current-buffer orig-buffer
+      (vundo-diff--quit)
       (run-hooks 'vundo-post-exit-hook))))
 
 ;;; Traverse undo tree


### PR DESCRIPTION
* vundo-diff.el (`vundo-diff--quit`, `vundo-diff`): New custom var
  `vundo-diff-quit`.  Attaches new function `vundo-diff--quit` to
  `vundo-post-exit-hook`, if `vundo-diff-quit` is non-nil.

`vundo-diff-quit=t` is the default, which means the window is buried but the buffer remains.  It can be set to `kill` to also kill the buffer. 