### PR TITLE
Navigate among all saved nodes with l/r

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,11 +8,13 @@ should pop up. To move around, type:
   f   to go forward
   b   to go backward
 
-  n   to go to the node below when you at a branching point
+  n   to go to the node below when at a branch point
   p   to go to the node above
 
   a   to go back to the last branching point
   e   to go forward to the end/tip of the branch
+  l   to go to the last saved node
+  r   to go to the next saved node
 
   m   to mark the current node for diff
   u   to unmark the marked node


### PR DESCRIPTION
Note: this is a cleaned-up version of PR #81.

This enables moving among all saved nodes, taking care to identify
timestamps across all equivalent nodes, and saving the timestamps
seen.  Timestamp handling and most recently saved node highlighting
have been simplified.

* README.txt: document l/r key bindings

* vundo.el (vundo--mod-timestamp, vundo--record-timestamps,
  vundo--timestamps): added new timestamp handling, recording all
  timestamps seen in the mod-list to vundo--timestamps variable, keyed
  by master equivalent node.

  (vundo--mod-timestamp): remove function, which is supplanted by
    vundo--node-timestamp.

  (vundo--highlight-last-saved-node): use the given timestamps list to
    find and highlight the last saved node.

  (vundo--draw-tree, vundo--refresh-buffer): Simplify drawing code by
    removing the last saved node search and highlighting, calling
    vundo--highlight-last-saved-node from vundo--refresh-buffer instead.

  (vundo--find-last-saved, vundo-goto-next-saved,
    vundo--last-saved-idx, vundo-goto-last-saved): Eliminate
    unnecessary variable last saved index.  Move forward and backward
    among saved nodes using vundo--find-last-saved to find adjacent
    saved nodes from a given node, with saved time reporting.  Added
    binding "r" for the new vundo-goto-next-saved command.