### PR TITLE
fixup: autoload vundo-diff--quit from vundo-diff.el

### DIFF
--- a/vundo-diff.el
+++ b/vundo-diff.el
@@ -129,6 +129,7 @@ NODE defaults to the current node."
       (delete-overlay vundo-diff--highlight-overlay)
       (setq vundo-diff--highlight-overlay nil))))
 
+;;;###autoload
 (defun vundo-diff--quit ()
   "Quit the `vundo-diff' window and possibly kill buffer."
   (let* ((buf (get-buffer (concat "*vundo-diff-" (buffer-name) "*")))


### PR DESCRIPTION
https://github.com/casouri/vundo/blob/c66abe86e12671ce46552a38d63a2b635bff23b9/vundo.el#L745-L748

`vundo-diff--quit` referenced in `vundo.el` is marked with `###autoload` so that it can be referenced from it.

Fixes #104.