### PR TITLE
Move to beginning of next stem

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ should pop up. To move around, type:
   p   to go to the node above
 
   a   to go back to the last branching point
+  w   to go forward to the next branching point
   e   to go forward to the end/tip of the branch
   l   to go to the last saved node
   r   to go to the next saved node

--- a/vundo.el
+++ b/vundo.el
@@ -756,6 +756,7 @@ WINDOW is the window that was/is displaying the vundo buffer."
     (define-key map (kbd "p") #'vundo-previous)
     (define-key map (kbd "<up>") #'vundo-previous)
     (define-key map (kbd "a") #'vundo-stem-root)
+    (define-key map (kbd "w") #'vundo-next-root)
     (define-key map (kbd "e") #'vundo-stem-end)
     (define-key map (kbd "l") #'vundo-goto-last-saved)
     (define-key map (kbd "r") #'vundo-goto-next-saved)
@@ -1318,6 +1319,29 @@ If ARG < 0, move forward."
         this next vundo--orig-buffer vundo--prev-mod-list)
        (setq this next
              next (vundo-m-parent this)))
+     (vundo--trim-undo-list
+      vundo--orig-buffer this vundo--prev-mod-list)
+     (vundo--refresh-buffer
+      vundo--orig-buffer (current-buffer)
+      'incremental))))
+
+(defun vundo-next-root ()
+  "Move to the beginning of the next stem."
+  (interactive)
+  (vundo--check-for-command
+   (when-let* ((this (vundo--current-node vundo--prev-mod-list))
+               ;; If NEXT is nil, ie. this node doesn’t have a child, do
+               ;; nothing.
+               (next (car (vundo-m-children this))))
+     (vundo--move-to-node
+      this next vundo--orig-buffer vundo--prev-mod-list)
+     (setq this next
+           next (car (vundo-m-children this)))
+     (while (and next (not (vundo--stem-root-p this)))
+       (vundo--move-to-node
+        this next vundo--orig-buffer vundo--prev-mod-list)
+       (setq this next
+             next (car (vundo-m-children this))))
      (vundo--trim-undo-list
       vundo--orig-buffer this vundo--prev-mod-list)
      (vundo--refresh-buffer


### PR DESCRIPTION
To switch branches, one needs to be on a stem root (branchpoint). Add a command to make it easier to move between stem roots (meant to be used along with `vundo-stem-root`).

I don't have FSF papers yet; let me know if you'd be willing to merge this and I'll look into it.