### PR TITLE
Add truncate-at-node for timestamp-based undo-list truncation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,6 +20,7 @@ should pop up. To move around, type:
   m   to mark the current node for diff
   u   to unmark the marked node
   d   to show a diff between the marked (or parent) and current nodes
+  K   to truncate the undo list prior to a selected time-stamped node
 
   q   to quit, you can also type C-g
 


### PR DESCRIPTION
Includes new key binding `K` to select a (saved) node by date, and trim the undo-list prior to that node.  Works well in limited testing.

This also resets `vundo--roll-back-to-this`, which we might argue should be dune in `vundo--refresh-buffer` (since the nodes will have changed from entry).