### PR TITLE
fix: popup is global, mode should be too

### DIFF
--- a/vundo-popup.el
+++ b/vundo-popup.el
@@ -142,6 +142,7 @@ nil means to use the default.  Only effects popups created by
 (define-minor-mode vundo-popup-mode
   "Display a vundo popup when using any ordinary undo command."
   :group 'vundo
+  :global t
   (dolist (cmd vundo-popup-commands)
     (if vundo-popup-mode
         (advice-add cmd :after ;call CMD first: this way undoing in region works out of the box


### PR DESCRIPTION
Activating `vundo-popup-mode` affects all buffers, so the mode variable should be global, not buffer-local.

Really all this change does is allow you to deactivate the mode from a different buffer than you initially activated it in.

### Alternatives:
The advice could be modified to check the mode before acting, allowing the mode to only affect a subset of buffers. i prefer it as a global mode, though, so i haven't implemented this.

### Notes:
I haven't yet signed the gnu contributor agreement yet, but this change is below the size limit for small contributions, so i figure it is acceptable.